### PR TITLE
Add modern spec-driven API scaffolding and integration tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,20 @@ project(t81 LANGUAGES CXX)
 option(T81_BUILD_EXAMPLES "Build T81 C++ examples" ON)
 option(T81_BUILD_TESTS    "Build T81 C++ unit tests" ON)
 
-add_library(t81 INTERFACE)
-target_compile_features(t81 INTERFACE cxx_std_17)
-target_include_directories(t81 INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+add_library(t81 STATIC
+  src/core/bigint.cpp
+  src/core/fraction.cpp
+  src/tisc/encoding.cpp
+  src/vm/vm.cpp
+  src/lang/compiler.cpp
+  src/canonfs/in_memory_driver.cpp
+  src/hanoi/error.cpp
+  src/hanoi/in_memory_kernel.cpp
+  src/axion/engine.cpp
+  src/cog/promotion.cpp
+)
+target_compile_features(t81 PUBLIC cxx_std_20)
+target_include_directories(t81 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # IO sources that need compilation
 add_library(t81_io STATIC
@@ -99,4 +110,10 @@ if (T81_BUILD_TESTS)
 
   add_executable(t81_tensor_unary_test tests/cpp/tensor_unary_test.cpp)
   target_link_libraries(t81_tensor_unary_test PRIVATE t81)
+
+  add_executable(t81_hanoi_integration_test tests/cpp/hanoi_integration_test.cpp)
+  target_link_libraries(t81_hanoi_integration_test PRIVATE t81)
+
+  add_executable(t81_lang_vm_test tests/cpp/lang_vm_integration_test.cpp)
+  target_link_libraries(t81_lang_vm_test PRIVATE t81)
 endif()

--- a/include/t81/axion/context.hpp
+++ b/include/t81/axion/context.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+#include "t81/hanoi/types.hpp"
+
+namespace t81::axion {
+// Syscall context used by policy evaluation without colliding with legacy Context.
+struct SyscallContext {
+  t81::hanoi::SnapshotRef snapshot;
+  std::string caller;
+  std::string syscall;
+};
+}  // namespace t81::axion
+

--- a/include/t81/axion/engine.hpp
+++ b/include/t81/axion/engine.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <memory>
+#include "t81/axion/context.hpp"
+#include "t81/axion/verdict.hpp"
+
+namespace t81::axion {
+class Engine {
+ public:
+  virtual ~Engine() = default;
+  virtual Verdict evaluate(const SyscallContext& context) = 0;
+};
+
+std::unique_ptr<Engine> make_allow_all_engine();
+}  // namespace t81::axion
+

--- a/include/t81/axion/verdict.hpp
+++ b/include/t81/axion/verdict.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+namespace t81::axion {
+enum class VerdictKind { Allow, Deny, Defer };
+
+struct Verdict {
+  VerdictKind kind{VerdictKind::Defer};
+  std::string reason;
+};
+}  // namespace t81::axion
+

--- a/include/t81/canonfs/canon_driver.hpp
+++ b/include/t81/canonfs/canon_driver.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <memory>
+#include <span>
+#include <vector>
+#include <t81/support/expected.hpp>
+#include "t81/canonfs/canon_types.hpp"
+
+namespace t81::canonfs {
+enum class Error {
+  None = 0,
+  NotFound,
+  InvalidObject,
+  CapabilityError,
+  ParityFailure,
+};
+
+template <typename T>
+using Result = std::expected<T, Error>;
+
+class Driver {
+ public:
+  virtual ~Driver() = default;
+  virtual Result<CanonRef> write_object(ObjectType type, std::span<const std::byte> bytes) = 0;
+  virtual Result<std::vector<std::byte>> read_object_bytes(const CanonRef& ref) = 0;
+  virtual Result<void> publish_capability(const CapabilityGrant& grant) = 0;
+  virtual Result<void> revoke_capability(const CanonRef& ref) = 0;
+  virtual Result<void> parity_repair_subtree(const CanonRef& ref) = 0;
+};
+
+// Utility factory for the in-memory driver implementation.
+std::unique_ptr<Driver> make_in_memory_driver();
+}  // namespace t81::canonfs
+

--- a/include/t81/canonfs/canon_types.hpp
+++ b/include/t81/canonfs/canon_types.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include "t81/core/base81.hpp"
+
+namespace t81::canonfs {
+using CanonHash = t81::core::Base81String;
+
+// Canonical object kinds per spec/canonfs-spec.md.
+enum class ObjectType : std::uint8_t {
+  Blob = 0,
+  Directory = 1,
+  Capability = 2,
+  ParityShard = 3,
+};
+
+struct CanonRef {
+  CanonHash hash;  // Content address (spec/canonfs-spec.md §2).
+};
+
+struct CapabilityGrant {
+  CanonRef target;
+  std::string subject;  // Placeholder identity; TODO align with spec identity model.
+};
+
+struct CanonLink {
+  std::string name;
+  CanonRef ref;
+};
+
+struct CanonParityShard {
+  CanonRef original;
+  std::vector<std::byte> shard_data;
+};
+}  // namespace t81::canonfs
+

--- a/include/t81/canonical.hpp
+++ b/include/t81/canonical.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <string_view>
+
+// Canonical invariants for the T81 platform. See spec/v1.1.0-canonical.md.
+namespace t81 {
+inline constexpr std::string_view kVersion = "v1.1.0-canonical";
+inline constexpr bool kDeterministic = true;  // All execution must be deterministic per spec.
+inline constexpr bool kTernaryNative = true;  // Core arithmetic defined in balanced ternary.
+}  // namespace t81
+

--- a/include/t81/cog/metrics.hpp
+++ b/include/t81/cog/metrics.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace t81::cog {
+struct Metrics {
+  double entropy{0.0};
+  double coherence{0.0};
+};
+}  // namespace t81::cog
+

--- a/include/t81/cog/promotion.hpp
+++ b/include/t81/cog/promotion.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <t81/support/expected.hpp>
+#include "t81/axion/engine.hpp"
+#include "t81/cog/tier.hpp"
+
+namespace t81::cog {
+enum class PromotionError {
+  NotEligible,
+  AxionDenied,
+};
+
+template <typename T>
+using Result = std::expected<T, PromotionError>;
+
+Result<TierStatus> try_promote(const TierStatus& status, t81::axion::Engine& engine);
+}  // namespace t81::cog
+

--- a/include/t81/cog/tier.hpp
+++ b/include/t81/cog/tier.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+namespace t81::cog {
+enum class TierId {
+  Tier0,
+  Tier1,
+  Tier2,
+};
+
+struct TierStatus {
+  TierId current{TierId::Tier0};
+  std::string label;
+};
+}  // namespace t81::cog
+

--- a/include/t81/core/base81.hpp
+++ b/include/t81/core/base81.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace t81::core {
+// Base-81 textual representation used throughout the platform. See spec/t81-data-types.md.
+using Base81String = std::string;
+
+inline bool is_base81(std::string_view value) {
+  // Placeholder validation; TODO: enforce full alphabet per spec/t81-data-types.md.
+  return !value.empty();
+}
+}  // namespace t81::core
+

--- a/include/t81/core/bigint.hpp
+++ b/include/t81/core/bigint.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace t81::core {
+// Canonical big integer wrapper. Real implementation should match spec/t81-data-types.md.
+class BigInt {
+ public:
+  BigInt() = default;
+  explicit BigInt(std::int64_t v) : value_(v) {}
+
+  [[nodiscard]] std::int64_t value() const noexcept { return value_; }
+  [[nodiscard]] std::string to_string() const;
+
+ private:
+  std::int64_t value_{0};
+};
+}  // namespace t81::core
+

--- a/include/t81/core/fraction.hpp
+++ b/include/t81/core/fraction.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+#include "t81/core/bigint.hpp"
+
+namespace t81::core {
+// Rational number representation per spec/t81-data-types.md.
+struct Fraction {
+  BigInt numerator{};
+  BigInt denominator{1};
+
+  [[nodiscard]] std::string to_string() const;
+};
+}  // namespace t81::core
+

--- a/include/t81/core/ids.hpp
+++ b/include/t81/core/ids.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+#include "t81/core/base81.hpp"
+
+namespace t81::core {
+// Canonical identifiers (hashes, addresses). See spec/t81-data-types.md.
+struct CanonicalId {
+  Base81String value;
+};
+
+inline CanonicalId make_id(const Base81String& value) { return CanonicalId{value}; }
+}  // namespace t81::core
+

--- a/include/t81/core/tensor.hpp
+++ b/include/t81/core/tensor.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace t81::core {
+// Minimal tensor container. TODO: align with full spec/t81-data-types.md tensor semantics.
+template <typename T>
+struct Tensor {
+  std::vector<std::size_t> shape;
+  std::vector<T> data;
+
+  [[nodiscard]] std::size_t total_size() const noexcept { return data.size(); }
+};
+}  // namespace t81::core
+

--- a/include/t81/detail/bitops.hpp
+++ b/include/t81/detail/bitops.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "bitopts.hpp"
+

--- a/include/t81/hanoi/error.hpp
+++ b/include/t81/hanoi/error.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+
+namespace t81::hanoi {
+enum class Error {
+  AxionRejection,
+  CapabilityMissing,
+  CapabilityRevoked,
+  CanonCorruption,
+  CanonMismatch,
+  InvalidExec,
+  OutOfMemory,
+  RepairError,
+  SealError,
+};
+
+std::string to_string(Error error);
+}  // namespace t81::hanoi
+

--- a/include/t81/hanoi/kernel.hpp
+++ b/include/t81/hanoi/kernel.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+#include <t81/support/expected.hpp>
+#include "t81/canonfs/canon_driver.hpp"
+#include "t81/hanoi/types.hpp"
+#include "t81/hanoi/error.hpp"
+
+namespace t81::hanoi {
+template <typename T>
+using Result = std::expected<T, Error>;
+
+class Kernel {
+ public:
+  virtual ~Kernel() = default;
+  virtual Result<SnapshotRef> fork_snapshot(const SnapshotRef& base) = 0;
+  virtual Result<SnapshotRef> commit_snapshot(const SnapshotRef& snapshot) = 0;
+  virtual Result<void> switch_root(const SnapshotRef& snapshot) = 0;
+  virtual Result<Pid> spawn(const SnapshotRef& snapshot) = 0;
+  virtual Result<std::vector<std::byte>> read_object(const t81::canonfs::CanonRef& ref) = 0;
+  virtual Result<void> grant_cap(const t81::canonfs::CapabilityGrant& grant) = 0;
+  virtual Result<void> revoke_cap(const t81::canonfs::CanonRef& ref) = 0;
+  virtual Result<void> yield_tick() = 0;
+  virtual Result<RegionHandle> map_region(std::size_t bytes) = 0;
+  virtual Result<void> parity_repair(const t81::canonfs::CanonRef& ref) = 0;
+  virtual Result<void> halt() = 0;
+};
+
+// Factory for the in-memory kernel simulator.
+std::unique_ptr<Kernel> make_in_memory_kernel(t81::canonfs::Driver& driver);
+}  // namespace t81::hanoi
+

--- a/include/t81/hanoi/types.hpp
+++ b/include/t81/hanoi/types.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstdint>
+#include "t81/canonfs/canon_types.hpp"
+
+namespace t81::hanoi {
+using SnapshotRef = t81::canonfs::CanonRef;
+using Pid = std::uint64_t;
+
+struct RegionHandle {
+  std::uint64_t id{0};
+};
+}  // namespace t81::hanoi
+

--- a/include/t81/io/tensor_loader.hpp
+++ b/include/t81/io/tensor_loader.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <istream>
+#include <ostream>
+
+#include "t81/tensor.hpp"
+
+namespace t81::io {
+// Parse text tensor representation (spec-driven placeholder).
+T729Tensor load_tensor_txt(std::istream& in);
+// Serialize tensor back to text.
+void save_tensor_txt(std::ostream& out, const T729Tensor& t);
+}  // namespace t81::io
+

--- a/include/t81/lang/ast.hpp
+++ b/include/t81/lang/ast.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+#include "t81/lang/types.hpp"
+
+namespace t81::lang {
+struct ExprLiteral {
+  std::int64_t value{0};
+};
+
+struct ExprBinary {
+  enum class Op { Add, Sub } op{Op::Add};
+  std::shared_ptr<struct Expr> lhs;
+  std::shared_ptr<struct Expr> rhs;
+};
+
+struct Expr {
+  std::variant<ExprLiteral, ExprBinary> node;
+};
+
+struct StatementReturn {
+  Expr expr;
+};
+
+using Statement = StatementReturn;
+
+struct Function {
+  std::string name;
+  Type return_type{Type::I64};
+  std::vector<Type> params;
+  std::vector<Statement> body;
+};
+
+struct Module {
+  std::vector<Function> functions;
+};
+}  // namespace t81::lang
+

--- a/include/t81/lang/compiler.hpp
+++ b/include/t81/lang/compiler.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <t81/support/expected.hpp>
+#include "t81/lang/ast.hpp"
+#include "t81/tisc/program.hpp"
+
+namespace t81::lang {
+enum class CompileError {
+  None = 0,
+  UnsupportedType,
+  EmptyModule,
+};
+
+class Compiler {
+ public:
+  std::expected<t81::tisc::Program, CompileError> compile(const Module& module) const;
+};
+}  // namespace t81::lang
+

--- a/include/t81/lang/types.hpp
+++ b/include/t81/lang/types.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace t81::lang {
+enum class Type {
+  I64,
+};
+}  // namespace t81::lang
+

--- a/include/t81/support/expected.hpp
+++ b/include/t81/support/expected.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <utility>
+#include <variant>
+
+// Lightweight compatibility wrapper for std::expected.
+// The implementation prefers <expected> when available; otherwise it provides
+// a minimal deterministic substitute sufficient for the APIs in this repo.
+// See spec/v1.1.0-canonical.md for determinism requirements.
+
+#if __has_include(<expected>)
+#include <expected>
+#endif
+
+#if defined(__cpp_lib_expected)
+namespace t81 {
+using std::expected;
+}
+#else
+namespace t81 {
+
+// Minimal expected implementation for C++20 environments without <expected>.
+// This is intentionally simple and deterministic; it should be replaced with
+// the standard library implementation when available. // TODO: align with
+// std::expected semantics per C++23 when toolchains upgrade.
+template <typename T, typename E>
+class expected {
+ public:
+  expected(const T& value) : has_(true), storage_(value) {}
+  expected(T&& value) : has_(true), storage_(std::move(value)) {}
+  expected(const E& error) : has_(false), storage_(error) {}
+  expected(E&& error) : has_(false), storage_(std::move(error)) {}
+
+  [[nodiscard]] bool has_value() const noexcept { return has_; }
+  [[nodiscard]] explicit operator bool() const noexcept { return has_; }
+
+  T& value() { return std::get<T>(storage_); }
+  const T& value() const { return std::get<T>(storage_); }
+  E& error() { return std::get<E>(storage_); }
+  const E& error() const { return std::get<E>(storage_); }
+
+ private:
+  bool has_;
+  std::variant<T, E> storage_;
+};
+
+// Partial specialization for void success.
+template <typename E>
+class expected<void, E> {
+ public:
+  expected() : has_(true) {}
+  expected(const E& error) : has_(false), error_(error) {}
+  expected(E&& error) : has_(false), error_(std::move(error)) {}
+
+  [[nodiscard]] bool has_value() const noexcept { return has_; }
+  [[nodiscard]] explicit operator bool() const noexcept { return has_; }
+
+  void value() const noexcept {}
+  E& error() { return error_; }
+  const E& error() const { return error_; }
+
+ private:
+  bool has_;
+  E error_{};
+};
+
+}  // namespace t81
+
+// Provide a shim in namespace std so code can use std::expected in a
+// toolchain-agnostic way. This is a benign extension for portability.
+namespace std {
+template <typename T, typename E>
+using expected = ::t81::expected<T, E>;
+}
+#endif
+

--- a/include/t81/t81.hpp
+++ b/include/t81/t81.hpp
@@ -40,3 +40,48 @@
 #include "t81/entropy.hpp"
 #include "t81/detail/assert.hpp"
 #include "t81/detail/bitops.hpp"
+
+// ---------- Canonical v1.1 surface ----------
+#include "t81/canonical.hpp"
+
+// ---------- Modern core (spec-driven) ----------
+#include "t81/support/expected.hpp"
+#include "t81/core/base81.hpp"
+#include "t81/core/bigint.hpp"
+#include "t81/core/fraction.hpp"
+#include "t81/core/tensor.hpp"
+#include "t81/core/ids.hpp"
+
+// ---------- TISC ISA ----------
+#include "t81/tisc/opcodes.hpp"
+#include "t81/tisc/program.hpp"
+#include "t81/tisc/encoding.hpp"
+
+// ---------- VM ----------
+#include "t81/vm/state.hpp"
+#include "t81/vm/traps.hpp"
+#include "t81/vm/vm.hpp"
+
+// ---------- T81Lang ----------
+#include "t81/lang/types.hpp"
+#include "t81/lang/ast.hpp"
+#include "t81/lang/compiler.hpp"
+
+// ---------- CanonFS ----------
+#include "t81/canonfs/canon_types.hpp"
+#include "t81/canonfs/canon_driver.hpp"
+
+// ---------- Hanoi microkernel ----------
+#include "t81/hanoi/types.hpp"
+#include "t81/hanoi/error.hpp"
+#include "t81/hanoi/kernel.hpp"
+
+// ---------- Axion ----------
+#include "t81/axion/verdict.hpp"
+#include "t81/axion/context.hpp"
+#include "t81/axion/engine.hpp"
+
+// ---------- Cognitive tiers ----------
+#include "t81/cog/tier.hpp"
+#include "t81/cog/promotion.hpp"
+#include "t81/cog/metrics.hpp"

--- a/include/t81/tensor.hpp
+++ b/include/t81/tensor.hpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <initializer_list>
 #include <algorithm>
+#include <numeric>
 
 namespace t81 {
 

--- a/include/t81/tisc/encoding.hpp
+++ b/include/t81/tisc/encoding.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+#include <t81/support/expected.hpp>
+#include "t81/tisc/program.hpp"
+
+namespace t81::tisc {
+enum class EncodingError {
+  None = 0,
+  Truncated,
+  InvalidOpcode,
+};
+
+std::vector<std::byte> encode(const Program& program);
+std::expected<Program, EncodingError> decode(const std::vector<std::byte>& bytes);
+}  // namespace t81::tisc
+

--- a/include/t81/tisc/opcodes.hpp
+++ b/include/t81/tisc/opcodes.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+
+namespace t81::tisc {
+// Opcode definitions per spec/tisc-spec.md. This is a subset placeholder.
+enum class Opcode : std::uint8_t {
+  Nop = 0,
+  Halt = 1,
+  LoadImm = 2,
+  Load = 3,
+  Store = 4,
+  Add = 5,
+  Sub = 6,
+  Jump = 7,
+  JumpIfZero = 8,
+};
+}  // namespace t81::tisc
+

--- a/include/t81/tisc/program.hpp
+++ b/include/t81/tisc/program.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include "t81/tisc/opcodes.hpp"
+
+namespace t81::tisc {
+struct Insn {
+  Opcode opcode{Opcode::Nop};
+  std::int32_t a{0};
+  std::int32_t b{0};
+  std::int32_t c{0};
+};
+
+struct Program {
+  std::vector<Insn> insns;
+};
+}  // namespace t81::tisc
+

--- a/include/t81/vm/state.hpp
+++ b/include/t81/vm/state.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <vector>
+#include "t81/tisc/program.hpp"
+
+namespace t81::vm {
+// Virtual machine register file per spec/t81vm-spec.md.
+struct State {
+  std::array<std::int64_t, 8> registers{};
+  std::vector<std::int64_t> memory;
+  std::size_t pc{0};
+  bool halted{false};
+};
+}  // namespace t81::vm
+

--- a/include/t81/vm/traps.hpp
+++ b/include/t81/vm/traps.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace t81::vm {
+enum class Trap {
+  None = 0,
+  InvalidMemory,
+  IllegalInstruction,
+};
+}  // namespace t81::vm
+

--- a/include/t81/vm/vm.hpp
+++ b/include/t81/vm/vm.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <memory>
+#include <t81/support/expected.hpp>
+#include "t81/vm/state.hpp"
+#include "t81/vm/traps.hpp"
+#include "t81/tisc/program.hpp"
+
+namespace t81::vm {
+class IVirtualMachine {
+ public:
+  virtual ~IVirtualMachine() = default;
+  virtual void load_program(const t81::tisc::Program& program) = 0;
+  virtual std::expected<void, Trap> step() = 0;
+  virtual std::expected<void, Trap> run_to_halt(std::size_t max_steps = 100000) = 0;
+  virtual const State& state() const = 0;
+};
+
+// Factory for the in-tree interpreter implementation.
+std::unique_ptr<IVirtualMachine> make_interpreter_vm();
+}  // namespace t81::vm
+

--- a/src/axion/engine.cpp
+++ b/src/axion/engine.cpp
@@ -1,0 +1,14 @@
+#include "t81/axion/engine.hpp"
+
+namespace t81::axion {
+class AllowAllEngine : public Engine {
+ public:
+  Verdict evaluate(const SyscallContext&) override {
+    // TODO: Implement full Axion policy (spec/axion-kernel.md).
+    return {VerdictKind::Allow, "TODO: full Axion policy"};
+  }
+};
+
+std::unique_ptr<Engine> make_allow_all_engine() { return std::make_unique<AllowAllEngine>(); }
+}  // namespace t81::axion
+

--- a/src/canonfs/in_memory_driver.cpp
+++ b/src/canonfs/in_memory_driver.cpp
@@ -1,0 +1,54 @@
+#include "t81/canonfs/canon_driver.hpp"
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace t81::canonfs {
+namespace {
+class InMemoryDriver : public Driver {
+ public:
+  Result<CanonRef> write_object(ObjectType, std::span<const std::byte> bytes) override {
+    CanonRef ref{CanonHash{next_hash()}};
+    objects_[ref.hash] = std::vector<std::byte>(bytes.begin(), bytes.end());
+    return ref;
+  }
+
+  Result<std::vector<std::byte>> read_object_bytes(const CanonRef& ref) override {
+    auto it = objects_.find(ref.hash);
+    if (it == objects_.end()) return Error::NotFound;
+    return it->second;
+  }
+
+  Result<void> publish_capability(const CapabilityGrant& grant) override {
+    capabilities_[grant.target.hash] = grant.subject;
+    return {};
+  }
+
+  Result<void> revoke_capability(const CanonRef& ref) override {
+    capabilities_.erase(ref.hash);
+    return {};
+  }
+
+  Result<void> parity_repair_subtree(const CanonRef& ref) override {
+    // Placeholder: mark parity repair succeeded. TODO: spec/canonfs-spec.md repair rules.
+    if (!objects_.count(ref.hash)) return Error::NotFound;
+    return {};
+  }
+
+ private:
+  std::string next_hash() {
+    // TODO: implement canonical hash (spec/canonfs-spec.md §hash). Placeholder counter-based.
+    return "mem-" + std::to_string(counter_++);
+  }
+
+  std::map<CanonHash, std::vector<std::byte>> objects_;
+  std::map<CanonHash, std::string> capabilities_;
+  std::size_t counter_{0};
+};
+}  // namespace
+
+std::unique_ptr<Driver> make_in_memory_driver() { return std::make_unique<InMemoryDriver>(); }
+}  // namespace t81::canonfs
+

--- a/src/cog/promotion.cpp
+++ b/src/cog/promotion.cpp
@@ -1,0 +1,28 @@
+#include "t81/cog/promotion.hpp"
+
+#include "t81/axion/context.hpp"
+
+namespace t81::cog {
+Result<TierStatus> try_promote(const TierStatus& status, t81::axion::Engine& engine) {
+  if (status.current == TierId::Tier2) {
+    return PromotionError::NotEligible;
+  }
+
+  t81::axion::SyscallContext ctx{{}, "system", "promote"};
+  auto verdict = engine.evaluate(ctx);
+  if (verdict.kind == t81::axion::VerdictKind::Deny) {
+    return PromotionError::AxionDenied;
+  }
+
+  TierStatus next = status;
+  if (status.current == TierId::Tier0) {
+    next.current = TierId::Tier1;
+    next.label = "Tier1";
+  } else if (status.current == TierId::Tier1) {
+    next.current = TierId::Tier2;
+    next.label = "Tier2";
+  }
+  return next;
+}
+}  // namespace t81::cog
+

--- a/src/core/bigint.cpp
+++ b/src/core/bigint.cpp
@@ -1,0 +1,8 @@
+#include "t81/core/bigint.hpp"
+
+#include <string>
+
+namespace t81::core {
+std::string BigInt::to_string() const { return std::to_string(value_); }
+}  // namespace t81::core
+

--- a/src/core/fraction.cpp
+++ b/src/core/fraction.cpp
@@ -1,0 +1,8 @@
+#include "t81/core/fraction.hpp"
+
+namespace t81::core {
+std::string Fraction::to_string() const {
+  return numerator.to_string() + "/" + denominator.to_string();
+}
+}  // namespace t81::core
+

--- a/src/hanoi/error.cpp
+++ b/src/hanoi/error.cpp
@@ -1,0 +1,28 @@
+#include "t81/hanoi/error.hpp"
+
+namespace t81::hanoi {
+std::string to_string(Error error) {
+  switch (error) {
+    case Error::AxionRejection:
+      return "AxionRejection";
+    case Error::CapabilityMissing:
+      return "CapabilityMissing";
+    case Error::CapabilityRevoked:
+      return "CapabilityRevoked";
+    case Error::CanonCorruption:
+      return "CanonCorruption";
+    case Error::CanonMismatch:
+      return "CanonMismatch";
+    case Error::InvalidExec:
+      return "InvalidExec";
+    case Error::OutOfMemory:
+      return "OutOfMemory";
+    case Error::RepairError:
+      return "RepairError";
+    case Error::SealError:
+      return "SealError";
+  }
+  return "Unknown";
+}
+}  // namespace t81::hanoi
+

--- a/src/hanoi/in_memory_kernel.cpp
+++ b/src/hanoi/in_memory_kernel.cpp
@@ -1,0 +1,98 @@
+#include "t81/hanoi/kernel.hpp"
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+#include "t81/axion/engine.hpp"
+
+namespace t81::hanoi {
+namespace {
+struct Snapshot {
+  t81::canonfs::CanonRef root;
+};
+
+class InMemoryKernel : public Kernel {
+ public:
+  explicit InMemoryKernel(t81::canonfs::Driver& driver) : driver_(driver) {
+    current_root_ = t81::canonfs::CanonRef{t81::canonfs::CanonHash{"root"}};
+    snapshots_[current_root_.hash] = Snapshot{current_root_};
+  }
+
+  Result<SnapshotRef> fork_snapshot(const SnapshotRef& base) override {
+    if (!snapshots_.count(base.hash)) return Error::CanonMismatch;
+    SnapshotRef child{t81::canonfs::CanonHash{base.hash + "-fork"}};
+    snapshots_[child.hash] = Snapshot{child};
+    return child;
+  }
+
+  Result<SnapshotRef> commit_snapshot(const SnapshotRef& snapshot) override {
+    if (!snapshots_.count(snapshot.hash)) return Error::CanonMismatch;
+    current_root_ = snapshot;
+    return snapshot;
+  }
+
+  Result<void> switch_root(const SnapshotRef& snapshot) override {
+    if (!snapshots_.count(snapshot.hash)) return Error::CanonMismatch;
+    current_root_ = snapshot;
+    return {};
+  }
+
+  Result<Pid> spawn(const SnapshotRef& snapshot) override {
+    if (!snapshots_.count(snapshot.hash)) return Error::CanonMismatch;
+    return static_cast<Pid>(++next_pid_);
+  }
+
+  Result<std::vector<std::byte>> read_object(const t81::canonfs::CanonRef& ref) override {
+    auto bytes = driver_.read_object_bytes(ref);
+    if (!bytes) return Error::CapabilityMissing;
+    return bytes.value();
+  }
+
+  Result<void> grant_cap(const t81::canonfs::CapabilityGrant& grant) override {
+    auto res = driver_.publish_capability(grant);
+    if (!res) return Error::CapabilityRevoked;
+    return {};
+  }
+
+  Result<void> revoke_cap(const t81::canonfs::CanonRef& ref) override {
+    auto res = driver_.revoke_capability(ref);
+    if (!res) return Error::CapabilityRevoked;
+    return {};
+  }
+
+  Result<void> yield_tick() override { return {}; }
+
+  Result<RegionHandle> map_region(std::size_t bytes) override {
+    RegionHandle handle{next_region_++};
+    regions_[handle.id] = std::vector<std::byte>(bytes);
+    return handle;
+  }
+
+  Result<void> parity_repair(const t81::canonfs::CanonRef& ref) override {
+    auto res = driver_.parity_repair_subtree(ref);
+    if (!res) return Error::RepairError;
+    return {};
+  }
+
+  Result<void> halt() override {
+    halted_ = true;
+    return {};
+  }
+
+ private:
+  t81::canonfs::Driver& driver_;
+  std::map<t81::canonfs::CanonHash, Snapshot> snapshots_;
+  SnapshotRef current_root_;
+  std::map<std::uint64_t, std::vector<std::byte>> regions_;
+  std::uint64_t next_region_{1};
+  std::uint64_t next_pid_{0};
+  bool halted_{false};
+};
+}  // namespace
+
+std::unique_ptr<Kernel> make_in_memory_kernel(t81::canonfs::Driver& driver) {
+  return std::make_unique<InMemoryKernel>(driver);
+}
+}  // namespace t81::hanoi
+

--- a/src/lang/compiler.cpp
+++ b/src/lang/compiler.cpp
@@ -1,0 +1,40 @@
+#include "t81/lang/compiler.hpp"
+
+#include <vector>
+
+namespace t81::lang {
+namespace {
+void emit_expr(const Expr& expr, std::vector<t81::tisc::Insn>& out, int target_reg) {
+  if (std::holds_alternative<ExprLiteral>(expr.node)) {
+    const auto& lit = std::get<ExprLiteral>(expr.node);
+    out.push_back({t81::tisc::Opcode::LoadImm, target_reg, static_cast<std::int32_t>(lit.value), 0});
+  } else {
+    const auto& bin = std::get<ExprBinary>(expr.node);
+    int lhs_reg = target_reg;
+    int rhs_reg = target_reg + 1;
+    emit_expr(*bin.lhs, out, lhs_reg);
+    emit_expr(*bin.rhs, out, rhs_reg);
+    const auto opcode = bin.op == ExprBinary::Op::Add ? t81::tisc::Opcode::Add : t81::tisc::Opcode::Sub;
+    out.push_back({opcode, target_reg, lhs_reg, rhs_reg});
+  }
+}
+}  // namespace
+
+std::expected<t81::tisc::Program, CompileError> Compiler::compile(const Module& module) const {
+  if (module.functions.empty()) {
+    return CompileError::EmptyModule;
+  }
+  t81::tisc::Program program;
+  for (const auto& fn : module.functions) {
+    if (fn.return_type != Type::I64) {
+      return CompileError::UnsupportedType;
+    }
+    for (const auto& stmt : fn.body) {
+      emit_expr(stmt.expr, program.insns, 0);
+      program.insns.push_back({t81::tisc::Opcode::Halt, 0, 0, 0});
+    }
+  }
+  return program;
+}
+}  // namespace t81::lang
+

--- a/src/tisc/encoding.cpp
+++ b/src/tisc/encoding.cpp
@@ -1,0 +1,52 @@
+#include "t81/tisc/encoding.hpp"
+
+#include <cstring>
+
+namespace t81::tisc {
+std::vector<std::byte> encode(const Program& program) {
+  std::vector<std::byte> bytes;
+  bytes.reserve(program.insns.size() * sizeof(Insn));
+  for (const auto& insn : program.insns) {
+    const auto opcode = static_cast<std::uint8_t>(insn.opcode);
+    bytes.push_back(static_cast<std::byte>(opcode));
+    auto append = [&bytes](std::int32_t v) {
+      for (int i = 0; i < 4; ++i) {
+        bytes.push_back(static_cast<std::byte>((v >> (i * 8)) & 0xFF));
+      }
+    };
+    append(insn.a);
+    append(insn.b);
+    append(insn.c);
+  }
+  return bytes;
+}
+
+std::expected<Program, EncodingError> decode(const std::vector<std::byte>& bytes) {
+  Program program;
+  constexpr std::size_t kInsnSize = 1 + 4 * 3;
+  if (bytes.size() % kInsnSize != 0) {
+    return EncodingError::Truncated;
+  }
+  for (std::size_t offset = 0; offset < bytes.size(); offset += kInsnSize) {
+    Insn insn;
+    const auto opcode = static_cast<std::uint8_t>(bytes[offset]);
+    if (opcode > static_cast<std::uint8_t>(Opcode::JumpIfZero)) {
+      return EncodingError::InvalidOpcode;
+    }
+    insn.opcode = static_cast<Opcode>(opcode);
+    auto read = [&bytes, offset](std::size_t index) {
+      std::int32_t value = 0;
+      for (int i = 0; i < 4; ++i) {
+        value |= static_cast<std::int32_t>(bytes[offset + 1 + index * 4 + i]) << (i * 8);
+      }
+      return value;
+    };
+    insn.a = read(0);
+    insn.b = read(1);
+    insn.c = read(2);
+    program.insns.push_back(insn);
+  }
+  return program;
+}
+}  // namespace t81::tisc
+

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -1,0 +1,87 @@
+#include "t81/vm/vm.hpp"
+
+#include <algorithm>
+#include <memory>
+
+namespace t81::vm {
+namespace {
+class Interpreter : public IVirtualMachine {
+ public:
+  void load_program(const t81::tisc::Program& program) override {
+    program_ = program;
+    state_ = State{};
+    state_.memory.resize(256, 0);
+  }
+
+  std::expected<void, Trap> step() override {
+    if (state_.halted || state_.pc >= program_.insns.size()) {
+      state_.halted = true;
+      return {};
+    }
+    const auto& insn = program_.insns[state_.pc++];
+    switch (insn.opcode) {
+      case t81::tisc::Opcode::Nop:
+        break;
+      case t81::tisc::Opcode::Halt:
+        state_.halted = true;
+        break;
+      case t81::tisc::Opcode::LoadImm:
+        if (static_cast<std::size_t>(insn.a) >= state_.registers.size()) return Trap::IllegalInstruction;
+        state_.registers[insn.a] = insn.b;
+        break;
+      case t81::tisc::Opcode::Add:
+        if (static_cast<std::size_t>(insn.a) >= state_.registers.size() ||
+            static_cast<std::size_t>(insn.b) >= state_.registers.size() ||
+            static_cast<std::size_t>(insn.c) >= state_.registers.size()) {
+          return Trap::IllegalInstruction;
+        }
+        state_.registers[insn.a] = state_.registers[insn.b] + state_.registers[insn.c];
+        break;
+      case t81::tisc::Opcode::Sub:
+        if (static_cast<std::size_t>(insn.a) >= state_.registers.size() ||
+            static_cast<std::size_t>(insn.b) >= state_.registers.size() ||
+            static_cast<std::size_t>(insn.c) >= state_.registers.size()) {
+          return Trap::IllegalInstruction;
+        }
+        state_.registers[insn.a] = state_.registers[insn.b] - state_.registers[insn.c];
+        break;
+      case t81::tisc::Opcode::Jump:
+        if (insn.a < 0 || static_cast<std::size_t>(insn.a) >= program_.insns.size()) return Trap::IllegalInstruction;
+        state_.pc = static_cast<std::size_t>(insn.a);
+        break;
+      case t81::tisc::Opcode::JumpIfZero:
+        if (static_cast<std::size_t>(insn.b) >= state_.registers.size()) return Trap::IllegalInstruction;
+        if (state_.registers[insn.b] == 0) {
+          if (insn.a < 0 || static_cast<std::size_t>(insn.a) >= program_.insns.size()) return Trap::IllegalInstruction;
+          state_.pc = static_cast<std::size_t>(insn.a);
+        }
+        break;
+      case t81::tisc::Opcode::Load:
+      case t81::tisc::Opcode::Store:
+        // Memory operations omitted for brevity; TODO align with spec/t81vm-spec.md.
+        return Trap::InvalidMemory;
+    }
+    return {};
+  }
+
+  std::expected<void, Trap> run_to_halt(std::size_t max_steps) override {
+    for (std::size_t i = 0; i < max_steps && !state_.halted; ++i) {
+      auto result = step();
+      if (!result.has_value()) return result;
+    }
+    return {};
+  }
+
+  const State& state() const override { return state_; }
+
+ private:
+  State state_{};
+  t81::tisc::Program program_{};
+};
+}  // namespace
+
+std::unique_ptr<IVirtualMachine> make_interpreter_vm() {
+  return std::make_unique<Interpreter>();
+}
+}  // namespace t81::vm
+

--- a/tests/cpp/hanoi_integration_test.cpp
+++ b/tests/cpp/hanoi_integration_test.cpp
@@ -1,0 +1,36 @@
+#include <cassert>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "t81/t81.hpp"
+
+int main() {
+  auto driver = t81::canonfs::make_in_memory_driver();
+  auto kernel = t81::hanoi::make_in_memory_kernel(*driver);
+
+  t81::hanoi::SnapshotRef base{t81::canonfs::CanonHash{"root"}};
+  auto forked = kernel->fork_snapshot(base);
+  assert(forked.has_value());
+
+  std::string payload = "hello";
+  std::vector<std::byte> bytes(payload.size());
+  std::memcpy(bytes.data(), payload.data(), payload.size());
+
+  auto obj = driver->write_object(t81::canonfs::ObjectType::Blob, bytes);
+  assert(obj.has_value());
+
+  auto committed = kernel->commit_snapshot(forked.value());
+  assert(committed.has_value());
+  auto switched = kernel->switch_root(committed.value());
+  assert(switched.has_value());
+
+  auto read_back = kernel->read_object(obj.value());
+  assert(read_back.has_value());
+  auto& buffer = read_back.value();
+  std::string roundtrip(reinterpret_cast<char*>(buffer.data()), buffer.size());
+  assert(roundtrip == payload);
+
+  return 0;
+}
+

--- a/tests/cpp/lang_vm_integration_test.cpp
+++ b/tests/cpp/lang_vm_integration_test.cpp
@@ -1,0 +1,42 @@
+#include <cassert>
+#include <memory>
+
+#include "t81/t81.hpp"
+
+int main() {
+  using namespace t81::lang;
+
+  Expr lhs;
+  lhs.node = ExprLiteral{2};
+  Expr rhs;
+  rhs.node = ExprLiteral{3};
+
+  ExprBinary bin;
+  bin.op = ExprBinary::Op::Add;
+  bin.lhs = std::make_unique<Expr>(lhs);
+  bin.rhs = std::make_unique<Expr>(rhs);
+
+  Expr root;
+  root.node = bin;
+
+  Function fn;
+  fn.name = "main";
+  fn.return_type = Type::I64;
+  fn.body.push_back({root});
+
+  Module mod;
+  mod.functions.push_back(fn);
+
+  Compiler compiler;
+  auto program_res = compiler.compile(mod);
+  assert(program_res.has_value());
+
+  auto vm = t81::vm::make_interpreter_vm();
+  vm->load_program(program_res.value());
+  auto run_res = vm->run_to_halt();
+  assert(run_res.has_value());
+  assert(vm->state().registers[0] == 5);
+
+  return 0;
+}
+


### PR DESCRIPTION
## Summary
- add spec-aligned public headers for canonical invariants, core types, TISC, VM, language, CanonFS, Hanoi, Axion, and cognitive tiers
- implement lightweight in-memory CanonFS driver, Hanoi kernel simulator, TISC interpreter VM, Axion allow-all engine, and tier promotion helper
- extend build/test configuration and add integration tests for CanonFS/Hanoi flows and T81Lang-to-TISC execution

## Testing
- cmake -S . -B build -DT81_BUILD_EXAMPLES=OFF
- cmake --build build --target t81_hanoi_integration_test t81_lang_vm_test
- ./build/t81_hanoi_integration_test
- ./build/t81_lang_vm_test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69233dab1128832a81c83fa54a3ab30d)