### PR TITLE
Implement Option/Result type checking and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(t81 LANGUAGES C CXX)
 # Options
 option(T81_BUILD_EXAMPLES "Build T81 C++ examples" ON)
 option(T81_BUILD_TESTS    "Build T81 C++ unit tests" ON)
+option(T81_BUILD_BENCHMARKS "Build T81 benchmark suite" ON)
 
 add_library(t81_core STATIC
   src/core/bigint.cpp
@@ -202,6 +203,9 @@ if (T81_BUILD_TESTS)
   add_executable(t81_frontend_ir_generator_test tests/cpp/frontend_ir_generator_test.cpp)
   target_link_libraries(t81_frontend_ir_generator_test PRIVATE t81_frontend t81_tisc)
 
+  add_executable(t81_semantic_analyzer_option_result_test tests/cpp/semantic_analyzer_option_result_test.cpp)
+  target_link_libraries(t81_semantic_analyzer_option_result_test PRIVATE t81_frontend)
+
   add_executable(t81_tisc_binary_emitter_test tests/cpp/tisc_binary_emitter_test.cpp)
   target_link_libraries(t81_tisc_binary_emitter_test PRIVATE t81_tisc)
 
@@ -347,6 +351,7 @@ if (T81_BUILD_TESTS)
     t81_frontend_parser_generics_test
     t81_frontend_parser_legacy_rejection_test
     t81_frontend_ir_generator_test
+    t81_semantic_analyzer_option_result_test
     t81_tisc_binary_emitter_test
     # e2e_let_statement_test # Disabled due to pre-existing parser/VM integration bugs. See issue #124.
     # e2e_arithmetic_test # Disabled due to pre-existing parser/VM integration bugs. See issue #124.
@@ -359,7 +364,9 @@ if (T81_BUILD_TESTS)
 endif()
 
 # Benchmarks
-add_subdirectory(benchmarks)
+if (T81_BUILD_BENCHMARKS)
+  add_subdirectory(benchmarks)
+endif()
 
 # --- Doxygen Documentation ---
 find_package(Doxygen)

--- a/include/t81/core/Option.hpp
+++ b/include/t81/core/Option.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "t81/core/T81Maybe.hpp"
+
+namespace t81 {
+
+// Lightweight alias for the T81 optional type used by the T81Lang surface syntax.
+// Option<T> maps directly to T81Maybe<T> while keeping the familiar name for
+// language-level constructs and tests.
+template <typename T>
+using Option = T81Maybe<T>;
+
+} // namespace t81
+

--- a/include/t81/core/README.md
+++ b/include/t81/core/README.md
@@ -40,6 +40,8 @@ The following table provides a comprehensive inventory of all canonical data typ
 | `T81Tensor<E,R,Dims...>`| [T81Tensor.hpp](./T81Tensor.hpp) | A multi-dimensional array for high-performance numerical computing. |
 | | | |
 | **Semantic & Flow Control** | | |
+| `Option<T>` | [Option.hpp](./Option.hpp) | Alias for the language-facing `Option` built on `T81Maybe`. |
+| `Result<T,E>` | [Result.hpp](./Result.hpp) | Alias that maps the surface `Result` type to `T81Result`. |
 | `T81Maybe<T>` | [T81Maybe.hpp](./T81Maybe.hpp) | A ternary-native optional / Maybe type for handling absence of a value. |
 | `T81Result<T,E>` | [T81Result.hpp](./T81Result.hpp) | Represents a success (with a value) or a failure (with an error). |
 | `T81Promise<T>` | [T81Promise.hpp](./T81Promise.hpp) | A container for a value that may be computed asynchronously. |

--- a/include/t81/core/Result.hpp
+++ b/include/t81/core/Result.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "t81/core/T81Result.hpp"
+
+namespace t81 {
+
+// Alias to align the T81Lang surface type `Result[T, E]` with the core
+// implementation `T81Result<T, E>`.
+template <typename T, typename E>
+using Result = T81Result<T, E>;
+
+} // namespace t81
+

--- a/include/t81/core/all.hpp
+++ b/include/t81/core/all.hpp
@@ -71,6 +71,8 @@
 #include "t81/T81IOStream.hpp"      // 84 – Voice
 #include "t81/T81Maybe.hpp"         // 85 – Humility
 #include "t81/T81Result.hpp"        // 86 – Grace
+#include "t81/core/Option.hpp"      // 85' – Surface Option alias
+#include "t81/core/Result.hpp"      // 86' – Surface Result alias
 #include "t81/T81Promise.hpp"       // 87 – Patience
 #include "t81/T81Thread.hpp"        // 88 – Society
 #include "t81/T81Network.hpp"       // 89 – Connection

--- a/include/t81/frontend/semantic_analyzer.hpp
+++ b/include/t81/frontend/semantic_analyzer.hpp
@@ -11,6 +11,38 @@
 namespace t81 {
 namespace frontend {
 
+// Simple type system representation for semantic analysis
+struct Type {
+    enum class Kind {
+        Void,
+        Bool,
+        I2,
+        I8,
+        I16,
+        I32,
+        BigInt,
+        Float,
+        Fraction,
+        Vector,
+        Matrix,
+        Tensor,
+        Graph,
+        Option,
+        Result,
+        String,
+        Custom,
+        Unknown,
+        Error
+    };
+
+    Kind kind = Kind::Unknown;
+    std::vector<Type> params;
+    std::string custom_name;
+
+    [[nodiscard]] bool operator==(const Type& other) const;
+    [[nodiscard]] bool operator!=(const Type& other) const { return !(*this == other); }
+};
+
 // Simple symbol information for semantic analysis
 enum class SymbolKind {
     Variable,
@@ -20,6 +52,9 @@ enum class SymbolKind {
 struct SemanticSymbol {
     SymbolKind kind;
     Token declaration;  // Token where the symbol was declared
+    Type type;                      // Variable type or function return type
+    std::vector<Type> param_types;  // Only used for functions
+    bool is_defined = false;        // Functions get declared first, defined later
 };
 
 class SemanticAnalyzer : public StmtVisitor, public ExprVisitor {
@@ -52,6 +87,7 @@ public:
 private:
     const std::vector<std::unique_ptr<Stmt>>& _statements;
     bool _had_error = false;
+    std::vector<Type> _function_return_stack;
 
     // Scoped symbol table
     using Scope = std::unordered_map<std::string, SemanticSymbol>;
@@ -69,6 +105,20 @@ private:
     void define_symbol(const Token& name, SymbolKind kind);
     SemanticSymbol* resolve_symbol(const Token& name);
     bool is_defined_in_current_scope(const std::string& name) const;
+
+    // Type helpers
+    Type make_error_type();
+    Type type_from_token(const Token& name);
+    Type analyze_type_expr(const TypeExpr& expr);
+    bool is_numeric(const Type& type) const;
+    int numeric_rank(const Type& type) const;
+    Type widen_numeric(const Type& left, const Type& right, const Token& op);
+    bool is_assignable(const Type& target, const Type& value);
+    std::string type_to_string(const Type& type) const;
+    Type expect_condition_bool(const Expr& expr, const Token& location);
+    Type evaluate_expression(const Expr& expr);
+    void register_function_signatures();
+    Token extract_token(const Expr& expr) const;
 };
 
 } // namespace frontend

--- a/src/frontend/semantic_analyzer.cpp
+++ b/src/frontend/semantic_analyzer.cpp
@@ -1,8 +1,17 @@
 #include "t81/frontend/semantic_analyzer.hpp"
 #include <iostream>
+#include <sstream>
 
 namespace t81 {
 namespace frontend {
+
+bool Type::operator==(const Type& other) const {
+    if (kind != other.kind) return false;
+    if (kind == Kind::Custom) {
+        return custom_name == other.custom_name;
+    }
+    return params == other.params;
+}
 
 SemanticAnalyzer::SemanticAnalyzer(const std::vector<std::unique_ptr<Stmt>>& statements)
     : _statements(statements) {
@@ -22,7 +31,11 @@ void SemanticAnalyzer::analyze() {
         }
     }
 
-    // Second pass: analyze all statements
+    // Second pass: record all function signatures so calls can be checked even
+    // when definitions appear later in the source.
+    register_function_signatures();
+
+    // Third pass: analyze all statements and bodies
     for (const auto& stmt : _statements) {
         if (stmt) {  // Skip null statements from parse errors
             analyze(*stmt);
@@ -66,7 +79,7 @@ void SemanticAnalyzer::exit_scope() {
 void SemanticAnalyzer::define_symbol(const Token& name, SymbolKind kind) {
     if (!_scopes.empty()) {
         std::string name_str = std::string(name.lexeme);
-        _scopes.back()[name_str] = SemanticSymbol{kind, name};
+        _scopes.back()[name_str] = SemanticSymbol{kind, name, Type{}, {}, false};
     }
 }
 
@@ -87,44 +100,261 @@ bool SemanticAnalyzer::is_defined_in_current_scope(const std::string& name) cons
     return _scopes.back().find(name) != _scopes.back().end();
 }
 
+Type SemanticAnalyzer::make_error_type() {
+    return Type{Type::Kind::Error};
+}
+
+int SemanticAnalyzer::numeric_rank(const Type& type) const {
+    switch (type.kind) {
+        case Type::Kind::I2: return 1;
+        case Type::Kind::I8: return 2;
+        case Type::Kind::I16: return 3;
+        case Type::Kind::I32: return 4;
+        case Type::Kind::BigInt: return 5;
+        case Type::Kind::Fraction: return 6;
+        case Type::Kind::Float: return 7;
+        default: return 0;
+    }
+}
+
+bool SemanticAnalyzer::is_numeric(const Type& type) const {
+    return numeric_rank(type) > 0;
+}
+
+Type SemanticAnalyzer::type_from_token(const Token& name) {
+    switch (name.type) {
+        case TokenType::Void: return Type{Type::Kind::Void};
+        case TokenType::Bool: return Type{Type::Kind::Bool};
+        case TokenType::I2: return Type{Type::Kind::I2};
+        case TokenType::I8: return Type{Type::Kind::I8};
+        case TokenType::I16: return Type{Type::Kind::I16};
+        case TokenType::I32: return Type{Type::Kind::I32};
+        case TokenType::T81BigInt: return Type{Type::Kind::BigInt};
+        case TokenType::T81Float: return Type{Type::Kind::Float};
+        case TokenType::T81Fraction: return Type{Type::Kind::Fraction};
+        case TokenType::Vector: return Type{Type::Kind::Vector};
+        case TokenType::Matrix: return Type{Type::Kind::Matrix};
+        case TokenType::Tensor: return Type{Type::Kind::Tensor};
+        case TokenType::Graph: return Type{Type::Kind::Graph};
+        default: break;
+    }
+
+    std::string name_str{name.lexeme};
+    if (name_str == "Option") return Type{Type::Kind::Option};
+    if (name_str == "Result") return Type{Type::Kind::Result};
+    if (name_str == "T81String") return Type{Type::Kind::String};
+    return Type{Type::Kind::Custom, {}, name_str};
+}
+
+Type SemanticAnalyzer::analyze_type_expr(const TypeExpr& expr) {
+    auto result = expr.accept(*this);
+    if (result.has_value()) {
+        try {
+            return std::any_cast<Type>(result);
+        } catch (const std::bad_any_cast&) {
+            return make_error_type();
+        }
+    }
+    return make_error_type();
+}
+
+std::string SemanticAnalyzer::type_to_string(const Type& type) const {
+    switch (type.kind) {
+        case Type::Kind::Void: return "void";
+        case Type::Kind::Bool: return "bool";
+        case Type::Kind::I2: return "i2";
+        case Type::Kind::I8: return "i8";
+        case Type::Kind::I16: return "i16";
+        case Type::Kind::I32: return "i32";
+        case Type::Kind::BigInt: return "T81BigInt";
+        case Type::Kind::Float: return "T81Float";
+        case Type::Kind::Fraction: return "T81Fraction";
+        case Type::Kind::Vector: return "Vector";
+        case Type::Kind::Matrix: return "Matrix";
+        case Type::Kind::Tensor: return "Tensor";
+        case Type::Kind::Graph: return "Graph";
+        case Type::Kind::String: return "T81String";
+        case Type::Kind::Option:
+        case Type::Kind::Result: {
+            std::ostringstream oss;
+            oss << (type.kind == Type::Kind::Option ? "Option" : "Result");
+            if (!type.params.empty()) {
+                oss << '[';
+                for (size_t i = 0; i < type.params.size(); ++i) {
+                    if (i > 0) oss << ", ";
+                    oss << type_to_string(type.params[i]);
+                }
+                oss << ']';
+            }
+            return oss.str();
+        }
+        case Type::Kind::Custom: return type.custom_name;
+        case Type::Kind::Unknown: return "<unknown>";
+        case Type::Kind::Error: return "<error>";
+    }
+    return "<unknown>";
+}
+
+bool SemanticAnalyzer::is_assignable(const Type& target, const Type& value) {
+    if (target.kind == Type::Kind::Error || value.kind == Type::Kind::Error) return true;
+    if (target.kind == Type::Kind::Unknown || value.kind == Type::Kind::Unknown) return true;
+    if (target == value) return true;
+
+    if (target.kind == Type::Kind::Option && value.kind == Type::Kind::Option &&
+        !target.params.empty() && !value.params.empty()) {
+        return is_assignable(target.params[0], value.params[0]);
+    }
+
+    if (target.kind == Type::Kind::Result && value.kind == Type::Kind::Result &&
+        target.params.size() == 2 && value.params.size() == 2) {
+        return is_assignable(target.params[0], value.params[0]) &&
+               is_assignable(target.params[1], value.params[1]);
+    }
+
+    if (is_numeric(target) && is_numeric(value)) {
+        return numeric_rank(value) <= numeric_rank(target);
+    }
+
+    if (target.kind == Type::Kind::Custom && value.kind == Type::Kind::Custom) {
+        return target.custom_name == value.custom_name;
+    }
+
+    return false;
+}
+
+Type SemanticAnalyzer::widen_numeric(const Type& left, const Type& right, const Token& op) {
+    if (left.kind == Type::Kind::Error || right.kind == Type::Kind::Error) {
+        return make_error_type();
+    }
+    if (left.kind == Type::Kind::Unknown || right.kind == Type::Kind::Unknown) {
+        return Type{Type::Kind::Unknown};
+    }
+    if (!is_numeric(left) || !is_numeric(right)) {
+        error(op, "Operands must be numeric, got '" + type_to_string(left) + "' and '" + type_to_string(right) + "'.");
+        return make_error_type();
+    }
+    return numeric_rank(left) >= numeric_rank(right) ? left : right;
+}
+
+Type SemanticAnalyzer::evaluate_expression(const Expr& expr) {
+    auto result = analyze(expr);
+    if (!result.has_value()) {
+        return Type{Type::Kind::Unknown};
+    }
+    try {
+        return std::any_cast<Type>(result);
+    } catch (const std::bad_any_cast&) {
+        return make_error_type();
+    }
+}
+
+Type SemanticAnalyzer::expect_condition_bool(const Expr& expr, const Token& location) {
+    Type cond_type = evaluate_expression(expr);
+    if (!is_assignable(Type{Type::Kind::Bool}, cond_type)) {
+        error(location, "Condition must be bool, found '" + type_to_string(cond_type) + "'.");
+        return make_error_type();
+    }
+    return Type{Type::Kind::Bool};
+}
+
+void SemanticAnalyzer::register_function_signatures() {
+    for (const auto& stmt : _statements) {
+        const auto* func = dynamic_cast<const FunctionStmt*>(stmt.get());
+        if (!func) continue;
+
+        SemanticSymbol* symbol = resolve_symbol(func->name);
+        if (!symbol) continue;
+
+        std::vector<Type> param_types;
+        bool param_error = false;
+        for (const auto& param : func->params) {
+            if (!param.type) {
+                param_error = true;
+                error(param.name, "Parameter '" + std::string(param.name.lexeme) + "' is missing a type annotation.");
+                param_types.push_back(make_error_type());
+                continue;
+            }
+            param_types.push_back(analyze_type_expr(*param.type));
+        }
+
+        Type return_type = func->return_type ? analyze_type_expr(*func->return_type) : Type{Type::Kind::Void};
+        symbol->param_types = param_types;
+        symbol->type = return_type;
+        symbol->is_defined = !param_error;
+    }
+}
+
+Token SemanticAnalyzer::extract_token(const Expr& expr) const {
+    if (auto* binary = dynamic_cast<const BinaryExpr*>(&expr)) return binary->op;
+    if (auto* unary = dynamic_cast<const UnaryExpr*>(&expr)) return unary->op;
+    if (auto* literal = dynamic_cast<const LiteralExpr*>(&expr)) return literal->value;
+    if (auto* variable = dynamic_cast<const VariableExpr*>(&expr)) return variable->name;
+    if (auto* assign = dynamic_cast<const AssignExpr*>(&expr)) return assign->name;
+    if (auto* call = dynamic_cast<const CallExpr*>(&expr)) return extract_token(*call->callee);
+    if (auto* grouping = dynamic_cast<const GroupingExpr*>(&expr)) return extract_token(*grouping->expression);
+
+    return Token{TokenType::Illegal, "", 0, 0};
+}
+
 // --- Visitor Method Implementations ---
 
 std::any SemanticAnalyzer::visit(const ExpressionStmt& stmt) {
-    analyze(*stmt.expression);
+    evaluate_expression(*stmt.expression);
     return {};
 }
 
 std::any SemanticAnalyzer::visit(const VarStmt& stmt) {
-    // Check if variable is already defined in current scope
     if (is_defined_in_current_scope(std::string(stmt.name.lexeme))) {
         error(stmt.name, "Variable '" + std::string(stmt.name.lexeme) + "' is already defined in this scope.");
-    } else {
-        // Analyze initializer before defining (allows self-reference in some cases)
-        if (stmt.initializer) {
-            analyze(*stmt.initializer);
-        }
-        define_symbol(stmt.name, SymbolKind::Variable);
+        return {};
     }
-    return {};
+
+    Type declared_type = stmt.type ? analyze_type_expr(*stmt.type) : Type{Type::Kind::Unknown};
+    Type init_type = stmt.initializer ? evaluate_expression(*stmt.initializer) : Type{Type::Kind::Unknown};
+
+    if (declared_type.kind == Type::Kind::Unknown && init_type.kind == Type::Kind::Unknown) {
+        error(stmt.name, "Variable '" + std::string(stmt.name.lexeme) + "' requires a type annotation or initializer.");
+    }
+
+    if (declared_type.kind != Type::Kind::Unknown && init_type.kind != Type::Kind::Unknown &&
+        !is_assignable(declared_type, init_type)) {
+        error(stmt.name, "Cannot assign initializer of type '" + type_to_string(init_type) +
+                              "' to variable of type '" + type_to_string(declared_type) + "'.");
+    }
+
+    Type final_type = declared_type.kind == Type::Kind::Unknown ? init_type : declared_type;
+    define_symbol(stmt.name, SymbolKind::Variable);
+    if (auto* symbol = resolve_symbol(stmt.name)) {
+        symbol->type = final_type;
+    }
+    return final_type;
 }
 
 std::any SemanticAnalyzer::visit(const LetStmt& stmt) {
-    // Analyze the type expression (TypeExpr extends Expr, so we can analyze it directly)
-    if (stmt.type) {
-        analyze(*stmt.type);
-    }
-    
-    // Check if variable is already defined in current scope
     if (is_defined_in_current_scope(std::string(stmt.name.lexeme))) {
         error(stmt.name, "Variable '" + std::string(stmt.name.lexeme) + "' is already defined in this scope.");
-    } else {
-        // Analyze initializer before defining
-        if (stmt.initializer) {
-            analyze(*stmt.initializer);
-        }
-        define_symbol(stmt.name, SymbolKind::Variable);
+        return {};
     }
-    return {};
+
+    Type declared_type = stmt.type ? analyze_type_expr(*stmt.type) : Type{Type::Kind::Unknown};
+    Type init_type = stmt.initializer ? evaluate_expression(*stmt.initializer) : Type{Type::Kind::Unknown};
+
+    if (declared_type.kind == Type::Kind::Unknown && init_type.kind == Type::Kind::Unknown) {
+        error(stmt.name, "Constant '" + std::string(stmt.name.lexeme) + "' requires a type annotation or initializer.");
+    }
+
+    if (declared_type.kind != Type::Kind::Unknown && init_type.kind != Type::Kind::Unknown &&
+        !is_assignable(declared_type, init_type)) {
+        error(stmt.name, "Cannot assign initializer of type '" + type_to_string(init_type) +
+                              "' to constant of type '" + type_to_string(declared_type) + "'.");
+    }
+
+    Type final_type = declared_type.kind == Type::Kind::Unknown ? init_type : declared_type;
+    define_symbol(stmt.name, SymbolKind::Variable);
+    if (auto* symbol = resolve_symbol(stmt.name)) {
+        symbol->type = final_type;
+    }
+    return final_type;
 }
 
 std::any SemanticAnalyzer::visit(const BlockStmt& stmt) {
@@ -137,7 +367,8 @@ std::any SemanticAnalyzer::visit(const BlockStmt& stmt) {
 }
 
 std::any SemanticAnalyzer::visit(const IfStmt& stmt) {
-    analyze(*stmt.condition);
+    Token cond_token = extract_token(*stmt.condition);
+    expect_condition_bool(*stmt.condition, cond_token);
     analyze(*stmt.then_branch);
     if (stmt.else_branch) {
         analyze(*stmt.else_branch);
@@ -146,143 +377,303 @@ std::any SemanticAnalyzer::visit(const IfStmt& stmt) {
 }
 
 std::any SemanticAnalyzer::visit(const WhileStmt& stmt) {
-    analyze(*stmt.condition);
+    Token cond_token = extract_token(*stmt.condition);
+    expect_condition_bool(*stmt.condition, cond_token);
     analyze(*stmt.body);
     return {};
 }
 
 std::any SemanticAnalyzer::visit(const ReturnStmt& stmt) {
-    if (stmt.value) {
-        analyze(*stmt.value);
+    if (_function_return_stack.empty()) {
+        error(stmt.keyword, "Return statement outside of a function.");
+        return make_error_type();
     }
-    return {};
+
+    const Type expected = _function_return_stack.back();
+    if (!stmt.value) {
+        if (expected.kind != Type::Kind::Void) {
+            error(stmt.keyword, "Return type mismatch: expected '" + type_to_string(expected) + "' but got 'void'.");
+        }
+        return expected;
+    }
+
+    Type value_type = evaluate_expression(*stmt.value);
+    if (!is_assignable(expected, value_type)) {
+        error(stmt.keyword, "Return type mismatch: expected '" + type_to_string(expected) + "' but got '" +
+                                 type_to_string(value_type) + "'.");
+    }
+    return expected;
 }
 
 std::any SemanticAnalyzer::visit(const FunctionStmt& stmt) {
-    // Function is already declared in global scope during first pass
-    // Now we enter function scope and define parameters
+    SemanticSymbol* symbol = resolve_symbol(stmt.name);
+    if (!symbol) {
+        define_symbol(stmt.name, SymbolKind::Function);
+        symbol = resolve_symbol(stmt.name);
+    }
+
     enter_scope();
-    
-    // Define function parameters
-    for (const auto& param : stmt.params) {
+    _function_return_stack.push_back(symbol ? symbol->type : Type{Type::Kind::Unknown});
+
+    if (symbol && symbol->param_types.size() != stmt.params.size()) {
+        error(stmt.name, "Function parameter count mismatch between declaration and definition.");
+    }
+
+    for (size_t i = 0; i < stmt.params.size(); ++i) {
+        const auto& param = stmt.params[i];
+        Type param_type = (symbol && i < symbol->param_types.size()) ? symbol->param_types[i]
+                                                                     : Type{Type::Kind::Unknown};
+
+        if (param.type && param_type.kind == Type::Kind::Unknown) {
+            param_type = analyze_type_expr(*param.type);
+        }
+
         if (is_defined_in_current_scope(std::string(param.name.lexeme))) {
             error(param.name, "Parameter '" + std::string(param.name.lexeme) + "' is already defined.");
         } else {
             define_symbol(param.name, SymbolKind::Variable);
+            if (auto* param_symbol = resolve_symbol(param.name)) {
+                param_symbol->type = param_type;
+            }
         }
     }
-    
-    // Analyze function body
+
     for (const auto& statement : stmt.body) {
         analyze(*statement);
     }
-    
+
+    _function_return_stack.pop_back();
     exit_scope();
-    return {};
+    return symbol ? symbol->type : Type{Type::Kind::Unknown};
 }
 
 std::any SemanticAnalyzer::visit(const AssignExpr& expr) {
-    // Check if variable exists
     auto* symbol = resolve_symbol(expr.name);
     if (!symbol) {
         error(expr.name, "Undefined variable '" + std::string(expr.name.lexeme) + "'.");
-    } else if (symbol->kind != SymbolKind::Variable) {
+        evaluate_expression(*expr.value);
+        return make_error_type();
+    }
+    if (symbol->kind != SymbolKind::Variable) {
         error(expr.name, "Cannot assign to non-variable '" + std::string(expr.name.lexeme) + "'.");
     }
-    
-    analyze(*expr.value);
-    return {};
+
+    Type value_type = evaluate_expression(*expr.value);
+    if (!is_assignable(symbol->type, value_type)) {
+        error(expr.name, "Cannot assign value of type '" + type_to_string(value_type) +
+                             "' to variable of type '" + type_to_string(symbol->type) + "'.");
+    }
+    return symbol->type;
 }
 
 std::any SemanticAnalyzer::visit(const BinaryExpr& expr) {
-    analyze(*expr.left);
-    analyze(*expr.right);
-    return {};
+    Type left_type = evaluate_expression(*expr.left);
+    Type right_type = evaluate_expression(*expr.right);
+
+    switch (expr.op.type) {
+        case TokenType::Plus:
+        case TokenType::Minus:
+        case TokenType::Star:
+        case TokenType::Slash:
+        case TokenType::Percent:
+            return widen_numeric(left_type, right_type, expr.op);
+        case TokenType::Greater:
+        case TokenType::GreaterEqual:
+        case TokenType::Less:
+        case TokenType::LessEqual:
+            if (!is_numeric(left_type) || !is_numeric(right_type)) {
+                error(expr.op, "Comparison operands must be numeric.");
+                return make_error_type();
+            }
+            return Type{Type::Kind::Bool};
+        case TokenType::EqualEqual:
+        case TokenType::BangEqual: {
+            if (left_type == right_type) return Type{Type::Kind::Bool};
+            if (is_numeric(left_type) && is_numeric(right_type)) return Type{Type::Kind::Bool};
+            error(expr.op, "Equality operands must be of the same type.");
+            return make_error_type();
+        }
+        case TokenType::AmpAmp:
+        case TokenType::PipePipe:
+            if (!is_assignable(Type{Type::Kind::Bool}, left_type) ||
+                !is_assignable(Type{Type::Kind::Bool}, right_type)) {
+                error(expr.op, "Logical operators require boolean operands.");
+                return make_error_type();
+            }
+            return Type{Type::Kind::Bool};
+        default:
+            return make_error_type();
+    }
 }
 
 std::any SemanticAnalyzer::visit(const CallExpr& expr) {
-    analyze(*expr.callee);
+    std::vector<Type> arg_types;
+    arg_types.reserve(expr.arguments.size());
+    for (const auto& arg : expr.arguments) {
+        arg_types.push_back(evaluate_expression(*arg));
+    }
 
     if (auto var_expr = dynamic_cast<const VariableExpr*>(expr.callee.get())) {
         std::string func_name = std::string(var_expr->name.lexeme);
-        
-        // Special handling for built-in constructors
+
         if (func_name == "Some") {
-            if (expr.arguments.size() != 1) {
+            if (arg_types.size() != 1) {
                 error(var_expr->name, "The 'Some' constructor expects exactly one argument.");
             }
-        } else {
-            // Check if function is defined
-            auto* symbol = resolve_symbol(var_expr->name);
-            if (!symbol) {
-                error(var_expr->name, "Undefined function '" + func_name + "'.");
-            } else if (symbol->kind != SymbolKind::Function) {
-                error(var_expr->name, "'" + func_name + "' is not a function.");
+            return Type{Type::Kind::Option, {arg_types.empty() ? Type{Type::Kind::Unknown} : arg_types[0]}};
+        }
+        if (func_name == "None") {
+            if (!arg_types.empty()) {
+                error(var_expr->name, "The 'None' constructor does not take arguments.");
+            }
+            return Type{Type::Kind::Option, {Type{Type::Kind::Unknown}}};
+        }
+        if (func_name == "Ok") {
+            if (arg_types.size() != 1) {
+                error(var_expr->name, "The 'Ok' constructor expects exactly one argument.");
+            }
+            Type success = arg_types.empty() ? Type{Type::Kind::Unknown} : arg_types[0];
+            return Type{Type::Kind::Result, {success, Type{Type::Kind::Unknown}}};
+        }
+        if (func_name == "Err") {
+            if (arg_types.size() != 1) {
+                error(var_expr->name, "The 'Err' constructor expects exactly one argument.");
+            }
+            Type error_type = arg_types.empty() ? Type{Type::Kind::Unknown} : arg_types[0];
+            return Type{Type::Kind::Result, {Type{Type::Kind::Unknown}, error_type}};
+        }
+
+        auto* symbol = resolve_symbol(var_expr->name);
+        if (!symbol) {
+            error(var_expr->name, "Undefined function '" + func_name + "'.");
+            return make_error_type();
+        }
+        if (symbol->kind != SymbolKind::Function) {
+            error(var_expr->name, "'" + func_name + "' is not a function.");
+            return make_error_type();
+        }
+
+        if (symbol->param_types.size() != arg_types.size()) {
+            error(var_expr->name, "Function '" + func_name + "' expects " + std::to_string(symbol->param_types.size()) +
+                                       " arguments but got " + std::to_string(arg_types.size()) + ".");
+            return symbol->type;
+        }
+
+        for (size_t i = 0; i < arg_types.size(); ++i) {
+            if (!is_assignable(symbol->param_types[i], arg_types[i])) {
+                error(var_expr->name, "Argument " + std::to_string(i) + " for function '" + func_name + "' expects '" +
+                                           type_to_string(symbol->param_types[i]) + "' but got '" +
+                                           type_to_string(arg_types[i]) + "'.");
             }
         }
+
+        return symbol->type;
     }
 
-    for (const auto& arg : expr.arguments) {
-        analyze(*arg);
-    }
-    return {};
+    evaluate_expression(*expr.callee);
+    return make_error_type();
 }
 
 std::any SemanticAnalyzer::visit(const GroupingExpr& expr) {
-    return analyze(*expr.expression);
+    return evaluate_expression(*expr.expression);
 }
 
 std::any SemanticAnalyzer::visit(const LiteralExpr& expr) {
-    return {};
+    switch (expr.value.type) {
+        case TokenType::True:
+        case TokenType::False:
+            return Type{Type::Kind::Bool};
+        case TokenType::Integer:
+        case TokenType::Base81Integer:
+            return Type{Type::Kind::I32};
+        case TokenType::Float:
+        case TokenType::Base81Float:
+            return Type{Type::Kind::Float};
+        case TokenType::String:
+            return Type{Type::Kind::String};
+        default:
+            return Type{Type::Kind::Unknown};
+    }
 }
 
 std::any SemanticAnalyzer::visit(const UnaryExpr& expr) {
-    return analyze(*expr.right);
+    Type right = evaluate_expression(*expr.right);
+    if (expr.op.type == TokenType::Bang) {
+        if (!is_assignable(Type{Type::Kind::Bool}, right)) {
+            error(expr.op, "Logical not requires a boolean operand.");
+            return make_error_type();
+        }
+        return Type{Type::Kind::Bool};
+    }
+
+    if (expr.op.type == TokenType::Minus) {
+        if (!is_numeric(right)) {
+            error(expr.op, "Unary minus requires a numeric operand.");
+            return make_error_type();
+        }
+        return right;
+    }
+
+    return make_error_type();
 }
 
 std::any SemanticAnalyzer::visit(const VariableExpr& expr) {
-    // Resolve variable reference
     std::string name_str = std::string(expr.name.lexeme);
-    
-    // Don't error for built-in constructors
+
     if (name_str == "Some" || name_str == "None" || name_str == "Ok" || name_str == "Err") {
-        return {};
+        return Type{Type::Kind::Unknown};
     }
-    
+
     auto* symbol = resolve_symbol(expr.name);
     if (!symbol) {
         error(expr.name, "Undefined variable '" + name_str + "'.");
+        return make_error_type();
     }
-    return {};
+    return symbol->type;
 }
 
 std::any SemanticAnalyzer::visit(const SimpleTypeExpr& expr) {
-    return {};
+    return type_from_token(expr.name);
 }
 
 std::any SemanticAnalyzer::visit(const GenericTypeExpr& expr) {
     std::string type_name = std::string(expr.name.lexeme);
-    
-    // Check parameter counts for known generic types
-    if (type_name == "Option") {
-        if (expr.param_count != 1) {
-            error(expr.name, "The 'Option' type expects exactly one type parameter, but got " + std::to_string(expr.param_count) + ".");
-            // Still analyze parameters even if count is wrong
-        }
-    } else if (type_name == "Result") {
-        if (expr.param_count != 2) {
-            error(expr.name, "The 'Result' type expects exactly two type parameters, but got " + std::to_string(expr.param_count) + ".");
-            // Still analyze parameters even if count is wrong
-        }
-    }
-    
-    // Analyze type parameters
+    std::vector<Type> params;
+    params.reserve(expr.param_count);
+
     for (size_t i = 0; i < expr.param_count; ++i) {
-        if (expr.params[i]) {
-            analyze(*expr.params[i]);
+        if (!expr.params[i]) continue;
+        if (auto* type_expr = dynamic_cast<TypeExpr*>(expr.params[i].get())) {
+            params.push_back(analyze_type_expr(*type_expr));
+        } else {
+            error(expr.name, "Generic type parameters must be types.");
+            params.push_back(make_error_type());
         }
     }
-    return {};
+
+    if (type_name == "Option") {
+        if (params.size() != 1) {
+            error(expr.name, "The 'Option' type expects exactly one type parameter, but got " + std::to_string(params.size()) + ".");
+        }
+        if (params.empty()) {
+            params.push_back(Type{Type::Kind::Unknown});
+        }
+        return Type{Type::Kind::Option, params};
+    }
+
+    if (type_name == "Result") {
+        if (params.size() != 2) {
+            error(expr.name, "The 'Result' type expects exactly two type parameters, but got " + std::to_string(params.size()) + ".");
+        }
+        while (params.size() < 2) {
+            params.push_back(Type{Type::Kind::Unknown});
+        }
+        return Type{Type::Kind::Result, params};
+    }
+
+    Type base = type_from_token(expr.name);
+    base.params = params;
+    return base;
 }
 
 } // namespace frontend

--- a/tests/cpp/semantic_analyzer_option_result_test.cpp
+++ b/tests/cpp/semantic_analyzer_option_result_test.cpp
@@ -1,0 +1,92 @@
+#include "t81/frontend/lexer.hpp"
+#include "t81/frontend/parser.hpp"
+#include "t81/frontend/semantic_analyzer.hpp"
+
+#include <cassert>
+#include <iostream>
+#include <string>
+
+using namespace t81::frontend;
+
+void expect_semantic_success(const std::string& source) {
+    Lexer lexer(source);
+    Parser parser(lexer);
+    auto stmts = parser.parse();
+    assert(!parser.had_error());
+
+    SemanticAnalyzer analyzer(stmts);
+    analyzer.analyze();
+    assert(!analyzer.had_error());
+}
+
+void expect_semantic_failure(const std::string& source) {
+    Lexer lexer(source);
+    Parser parser(lexer);
+    auto stmts = parser.parse();
+    if (parser.had_error()) {
+        // Parsing already failed; that's acceptable for this helper.
+        return;
+    }
+
+    SemanticAnalyzer analyzer(stmts);
+    analyzer.analyze();
+    assert(analyzer.had_error());
+}
+
+int main() {
+    const std::string valid_option = R"(
+        fn make_option() -> Option[i32] {
+            let value: Option[i32] = Some(1);
+            return value;
+        }
+
+        fn main() -> i32 {
+            let other: Option[i32] = make_option();
+            return 0;
+        }
+    )";
+    expect_semantic_success(valid_option);
+
+    const std::string invalid_option = R"(
+        fn bad_option() -> Option[i32] {
+            let value: Option[i32] = Some(true);
+            return value;
+        }
+    )";
+    expect_semantic_failure(invalid_option);
+
+    const std::string valid_result = R"(
+        fn make_ok() -> Result[i32, T81String] {
+            return Ok(7);
+        }
+
+        fn make_err() -> Result[i32, T81String] {
+            return Err("boom");
+        }
+    )";
+    expect_semantic_success(valid_result);
+
+    const std::string invalid_result = R"(
+        fn bad_err() -> Result[i32, T81String] {
+            return Err(5);
+        }
+    )";
+    expect_semantic_failure(invalid_result);
+
+    const std::string numeric_widening = R"(
+        fn widen() -> i32 {
+            let a: i8 = 1;
+            let b: i32 = a + 2;
+            return b;
+        }
+
+        fn fail_widen() -> i8 {
+            let x: i2 = 1;
+            return x + 1.5;
+        }
+    )";
+    expect_semantic_failure(numeric_widening);
+
+    std::cout << "Semantic analyzer option/result tests passed!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement the SemanticAnalyzer type system with numeric widening, function signatures, return checking, and Option/Result constructors
- add Option/Result aliases to the core headers/documentation and make benchmarks optional via a CMake toggle
- add semantic analyzer end-to-end tests covering Option/Result typing and numeric widening constraints

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DT81_BUILD_BENCHMARKS=OFF
- cmake --build build --parallel
- ctest --test-dir build --output-on-failure


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c9c54d4e4832a89e181a798456e0f)