### PR TITLE
Document TODO accomplishments and expand Python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the T81 Foundation should be documented in this file. Fol
 
 ## [Unreleased]
 
+- expanded Python bindings (`src/python/t81_python.cpp`) to include `BigInt`, `Float`, and `Fraction` types from the `t81::v1` namespace, enabling AI researchers to interact with ternary primitives directly from Python.
+- added `t81 init <project_name>` command to the CLI to scaffold new ternary-native projects with a template `main.t81` and `README.md`.
+- migrated core ternary types (`T81BigInt`, `T81Float`, `T81Fraction`) to the `t81::v1` namespace to ensure long-term API stability and resolve header conflicts.
 - add a high-rank tensor demo and a graph demo to the `examples/` directory plus documentation so the suite of data-type demos now illustrates tensor indexing and adjacency matrix handling
 - expand `docs/guides/data-types-overview.md`, `docs/guides/demo-gallery.md`, `docs/index.md`, and `README.md` with descriptions and CLI commands for the new demos to keep the guides and gallery synchronized
 - ensure `scripts/run-demos.sh` compiles and runs the full demo suite (match → quaternion → high-rank tensor → graph) and document that automation with cross-references

--- a/TODO.md
+++ b/TODO.md
@@ -4,11 +4,11 @@ This document tracks long-term strategic goals and ecosystem enhancements that e
 
 ## Ecosystem & Tooling [P0]
 
-- [/] **Python Bindings:** Initial `pybind11` wrappers for `T81Tensor`, `T729IntTensor`, and `HanoiVM` implemented; expansion for full cognitive kernel support ongoing.
+- [/] **Python Bindings:** Initial `pybind11` wrappers for `T81Tensor`, `T729IntTensor`, `HanoiVM`, `BigInt`, `Float`, and `Fraction` implemented; expansion for full cognitive kernel support ongoing.
 - [ ] **IDE Support:** Develop language servers (LSP) and syntax highlighters for T81Lang (VS Code, Vim, Emacs).
 - [ ] **Package Management:** Implement a canonical package manager for T81Lang libraries and modules.
 - [ ] **Integrated Debugger:** Create a debugger for HanoiVM that allows stepping through TISC instructions and inspecting Axion state.
-- [ ] **CLI Assists:** Expand the `t81` CLI with project scaffolding, linting, and formatting tools.
+- [/] **CLI Assists:** Expand the `t81` CLI with project scaffolding (`init`), linting, and formatting tools.
 
 ## High-Tier Cognition [P1]
 

--- a/include/t81/cli/driver.hpp
+++ b/include/t81/cli/driver.hpp
@@ -29,5 +29,6 @@ int run_tisc(const std::filesystem::path& path);
 int check_syntax(const std::filesystem::path& path);
 int repl(const std::shared_ptr<t81::weights::ModelFile>& weights_model = nullptr,
          std::istream& input = std::cin);
+int init_project(const std::string& name);
 
 } // namespace t81::cli

--- a/include/t81/core/T81BigInt.hpp
+++ b/include/t81/core/T81BigInt.hpp
@@ -23,7 +23,7 @@
 #include <limits>
 #include <algorithm>
 
-namespace t81 {
+namespace t81::v1 {
 
 class T81BigInt {
 public:
@@ -375,4 +375,4 @@ public:
 // Convenience alias
 using BigInt = T81BigInt;
 
-} // namespace t81::core
+} // namespace t81::v1

--- a/include/t81/core/T81Float.hpp
+++ b/include/t81/core/T81Float.hpp
@@ -23,7 +23,7 @@
 #include <compare>
 #include <cstdlib> // fabsl, powl
 
-namespace t81 {
+namespace t81::v1 {
 
 template <std::size_t M, std::size_t E>
 class T81Float;
@@ -297,16 +297,11 @@ private:
 
     constexpr void set_exp(std::int64_t e) noexcept {
         for (size_type i = 0; i < E; ++i) {
-            std::int64_t digit_ll = e % 3;
+            int digit = static_cast<int>(e % 3);
             e /= 3;
-            int digit = static_cast<int>(digit_ll);
-            if (digit == 2) {
-                // 2 → -1 with carry
-                bits_[M + i] = Trit::N;
-                ++e;
-            } else {
-                bits_[M + i] = int_to_trit(digit);
-            }
+            if (digit > 1) { digit -= 3; ++e; }
+            if (digit < -1) { digit += 3; --e; }
+            bits_[M + i] = int_to_trit(digit);
         }
     }
 
@@ -605,4 +600,11 @@ using T81Float18_9 = T81Float<18, 9>;
 using T81Float27_9 = T81Float<27, 9>;
 using T81Float72_9 = T81Float<72, 9>;   // default for Vec3f, etc.
 
-} // namespace t81
+} // namespace t81::v1
+
+namespace t81 {
+    using v1::T81Float;
+    using v1::T81Float18_9;
+    using v1::T81Float27_9;
+    using v1::T81Float72_9;
+}

--- a/include/t81/core/T81Fraction.hpp
+++ b/include/t81/core/T81Fraction.hpp
@@ -20,7 +20,7 @@
 #include <cmath>
 #include <algorithm>
 
-namespace t81 {
+namespace t81::v1 {
 
 template <std::size_t TotalTrits = 81>
     requires (TotalTrits >= 13 && TotalTrits <= 324)
@@ -187,4 +187,4 @@ public:
 using T81Frac81  = T81Fraction<81>;
 using T81Frac162 = T81Fraction<162>;
 
-} // namespace t81::core
+} // namespace t81::v1

--- a/include/t81/core/T81Int.hpp
+++ b/include/t81/core/T81Int.hpp
@@ -41,9 +41,14 @@ constexpr inline Trit int_to_trit(int v) noexcept {
 }
 
 // Forward declarations
-template <std::size_t M, std::size_t E> class T81Float;
-template <std::size_t I, std::size_t F> class T81Fixed;
-template <std::size_t Trits> class T81Prob;
+namespace v1 {
+    template <std::size_t M, std::size_t E> class T81Float;
+    template <std::size_t I, std::size_t F> class T81Fixed;
+    template <std::size_t Trits> class T81Prob;
+}
+using v1::T81Float;
+using v1::T81Fixed;
+using v1::T81Prob;
 
 template <std::size_t N>
 class T81Int {

--- a/src/cli/driver.cpp
+++ b/src/cli/driver.cpp
@@ -885,4 +885,47 @@ int check_syntax(const fs::path& path) {
     return 0;
 }
 
+int init_project(const std::string& name) {
+    if (name.empty()) {
+        error("Project name cannot be empty");
+        return 1;
+    }
+
+    fs::path project_dir(name);
+    if (fs::exists(project_dir)) {
+        error("Directory already exists: " + name);
+        return 1;
+    }
+
+    try {
+        fs::create_directories(project_dir);
+
+        // Create main.t81
+        std::ofstream main_file(project_dir / "main.t81");
+        main_file << "// T81 Foundation Project: " << name << "\n"
+                  << "// Created by t81 init\n\n"
+                  << "let x = 81;\n"
+                  << "let y = 100;\n"
+                  << "let sum = x + y;\n"
+                  << "sum;\n";
+        main_file.close();
+
+        // Create README.md
+        std::ofstream readme_file(project_dir / "README.md");
+        readme_file << "# " << name << "\n\n"
+                    << "A ternary-native project built on the T81 Foundation stack.\n\n"
+                    << "## How to run\n\n"
+                    << "```bash\n"
+                    << "t81 run main.t81\n"
+                    << "```\n";
+        readme_file.close();
+
+        info("Project initialized in " + name);
+        return 0;
+    } catch (const std::exception& e) {
+        error("Failed to initialize project: " + std::string(e.what()));
+        return 1;
+    }
+}
+
 } // namespace t81::cli

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -89,6 +89,7 @@ Commands:
   compile <file.t81> [-o <file.tisc>]   Compile T81Lang → TISC bytecode
   run     <file.t81|.tisc>             Compile (if needed) and execute
   check   <file.t81>                   Syntax-check only
+  init    <project_name>               Scaffold a new T81 project
   lint    <file.t81>                   Alias for check; performs semantic analysis
   repl                                 Enter interactive REPL
   version                              Show version
@@ -228,7 +229,7 @@ Args parse_args(int argc, char* argv[]) {
         else {
             if (a.command == "benchmark") {
                 a.benchmark_args.emplace_back(argv[i]);
-            } else if (a.command == "weights") {
+            } else if (a.command == "weights" || a.command == "init") {
                 a.command_args.emplace_back(argv[i]);
             } else {
                 if (!a.input.empty()) {
@@ -476,6 +477,13 @@ int main(int argc, char* argv[]) {
 
         } else if (args.command == "benchmark") {
             return run_benchmark(argv[0], args);
+
+        } else if (args.command == "init") {
+            if (args.command_args.empty()) {
+                error("init requires a project name");
+                return 1;
+            }
+            return t81::cli::init_project(args.command_args[0]);
 
         } else if (args.command == "repl") {
             return t81::cli::repl(weights_model_ptr);

--- a/src/python/t81_python.cpp
+++ b/src/python/t81_python.cpp
@@ -1,6 +1,9 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include "t81/core/T81Int.hpp"
+#include "t81/core/T81BigInt.hpp"
+#include "t81/core/T81Float.hpp"
+#include "t81/core/T81Fraction.hpp"
 #include "t81/core/T81Tensor.hpp"
 #include "t81/tensor.hpp"
 #include "t81/vm/vm.hpp"
@@ -36,6 +39,40 @@ PYBIND11_MODULE(t81_python, m) {
         })
         .def_static("max_value", []() { return T81Int<81>::kMaxValue; })
         .def_static("min_value", []() { return T81Int<81>::kMinValue; });
+
+    // Bind T81BigInt
+    py::class_<v1::T81BigInt>(m, "BigInt")
+        .def(py::init<int64_t>())
+        .def("__add__", [](const v1::T81BigInt& a, const v1::T81BigInt& b) { return a + b; })
+        .def("__sub__", [](const v1::T81BigInt& a, const v1::T81BigInt& b) { return a - b; })
+        .def("__mul__", [](const v1::T81BigInt& a, const v1::T81BigInt& b) { return a * b; })
+        .def("__repr__", &v1::T81BigInt::str)
+        .def("to_int", &v1::T81BigInt::to_int64);
+
+    // Bind T81Float27_9
+    py::class_<v1::T81Float27_9>(m, "Float")
+        .def(py::init<double>())
+        .def("__add__", [](const v1::T81Float27_9& a, const v1::T81Float27_9& b) { return a + b; })
+        .def("__sub__", [](const v1::T81Float27_9& a, const v1::T81Float27_9& b) { return a - b; })
+        .def("__mul__", [](const v1::T81Float27_9& a, const v1::T81Float27_9& b) { return a * b; })
+        .def("__truediv__", [](const v1::T81Float27_9& a, const v1::T81Float27_9& b) { return a / b; })
+        .def("__repr__", [](const v1::T81Float27_9& f) { return std::to_string(f.to_double()); })
+        .def("to_double", &v1::T81Float27_9::to_double)
+        .def_static("from_double", &v1::T81Float27_9::from_double);
+
+    // Bind T81Frac81
+    py::class_<v1::T81Frac81>(m, "Fraction")
+        .def(py::init<int64_t>())
+        .def(py::init([](int64_t n, int64_t d) { return v1::T81Frac81(T81Int<81>(n), T81Int<81>(d)); }))
+        .def("__add__", [](const v1::T81Frac81& a, const v1::T81Frac81& b) { return a + b; })
+        .def("__sub__", [](const v1::T81Frac81& a, const v1::T81Frac81& b) { return a - b; })
+        .def("__mul__", [](const v1::T81Frac81& a, const v1::T81Frac81& b) { return a * b; })
+        .def("__truediv__", [](const v1::T81Frac81& a, const v1::T81Frac81& b) { return a / b; })
+        .def("__repr__", [](const v1::T81Frac81& f) {
+            return std::to_string(f.num().to_int64()) + "/" + std::to_string(f.den().to_int64());
+        })
+        .def("to_double", &v1::T81Frac81::to_double)
+        .def_static("from_double", &v1::T81Frac81::from_double, py::arg("value"), py::arg("max_iterations") = 64);
 
     // Bind T81Tensor<T81Int<81>, 1, 3>
     using Tensor1D3 = T81Tensor<T81Int<81>, 1, 3>;

--- a/tests/cpp/test_bigint_multilimb_ext.cpp
+++ b/tests/cpp/test_bigint_multilimb_ext.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 
 using namespace t81;
+using namespace t81::v1;
 
 void test_multilimb_addition() {
     // 3^40 is larger than int64_t max (~9e18 vs 1e19)


### PR DESCRIPTION
This submission documents the recent accomplishments of the T81 Foundation project in `TODO.md` and `CHANGELOG.md`. It also introduces several functional enhancements:

1. **Expanded Python Bindings**: The `t81_python` module now includes bindings for the core `BigInt`, `Float` (T81Float27_9), and `Fraction` (T81Frac81) types, enabling AI researchers to manipulate ternary primitives directly from Python.
2. **CLI Scaffolding**: Added a new `t81 init <name>` command that creates a new directory with a standard `main.t81` template and `README.md`.
3. **Namespace Stability**: Migrated the core high-level ternary types to `namespace t81::v1` as recommended by `AGENTS.md`. This resolves naming conflicts with legacy headers and ensures a clean path forward for the stable API. Backward-compatibility aliases for `T81Float` were provided in `namespace t81`.
4. **Bug Fixes**: Refactored the `set_exp` method in `T81Float` to correctly convert signed exponents into balanced ternary, fixing a bug that occurred with negative unbiased exponents.

Verification:
- All 108 C++ tests passed successfully.
- Manually verified the `t81 init` command and ensured the generated template compiles and runs.
- Verified the new Python bindings using a test script covering arithmetic and conversion for all new types.


---
*PR created automatically by Jules for task [8780444278187905800](https://jules.google.com/task/8780444278187905800) started by @t81dev*